### PR TITLE
bump all timeouts 30->60

### DIFF
--- a/app/client/src/components/DocGenDownloadBar.jsx
+++ b/app/client/src/components/DocGenDownloadBar.jsx
@@ -18,7 +18,7 @@ async function download(jobId) {
       null,
       {
         responseType: "arraybuffer", // needed for binaries unless you want pain
-        timeout: 30000, // override default timeout as this call could take a while
+        timeout: 60000, // override default timeout as this call could take a while
       }
     );
 

--- a/app/client/src/features/documents/DownloadCertificatesPage.jsx
+++ b/app/client/src/features/documents/DownloadCertificatesPage.jsx
@@ -25,7 +25,7 @@ async function download(jobId) {
       null,
       {
         responseType: "arraybuffer", // needed for binaries unless you want pain
-        timeout: 30000, // override default timeout as this call could take a while
+        timeout: 60000, // override default timeout as this call could take a while
       }
     );
 

--- a/app/client/src/features/documents/DownloadDairyTankNoticesPage.jsx
+++ b/app/client/src/features/documents/DownloadDairyTankNoticesPage.jsx
@@ -25,7 +25,7 @@ async function download(jobId) {
       null,
       {
         responseType: "arraybuffer", // needed for binaries unless you want pain
-        timeout: 30000, // override default timeout as this call could take a while
+        timeout: 60000, // override default timeout as this call could take a while
       }
     );
 

--- a/app/client/src/features/documents/DownloadRenewalsPage.jsx
+++ b/app/client/src/features/documents/DownloadRenewalsPage.jsx
@@ -25,7 +25,7 @@ async function download(jobId) {
       null,
       {
         responseType: "arraybuffer", // needed for binaries unless you want pain
-        timeout: 30000, // override default timeout as this call could take a while
+        timeout: 60000, // override default timeout as this call could take a while
       }
     );
 

--- a/app/client/src/features/documents/dairyNoticesSlice.js
+++ b/app/client/src/features/documents/dairyNoticesSlice.js
@@ -29,11 +29,7 @@ export const startDairyNoticeJob = createAsyncThunk(
   "dairyNotices/startDairyNoticeJob",
   async (data, thunkApi) => {
     try {
-      const response = await Api.post(
-        "documents/dairyNotices/startJob",
-        data,
-        60000
-      );
+      const response = await Api.post("documents/dairyNotices/startJob", data, 60000);
       return response.data;
     } catch (error) {
       if (error instanceof ApiError) {

--- a/app/client/src/utilities/api.ts
+++ b/app/client/src/utilities/api.ts
@@ -21,7 +21,7 @@ export class ApiError extends Error {
   }
 }
 
-const DEFAULT_TIMEOUT = 30000;
+const DEFAULT_TIMEOUT = 60000;
 
 const axiosInstance = axios.create({
   baseURL: "/api/v1",


### PR DESCRIPTION
Timeouts are hardcoded everywhere, the dairy page timeouts were increased but it seems that these routes are called directly elsewhere with a lower timeout. I have gone and increased every instance of a 30 second timeout to 60 seconds.