### PR TITLE
Configure Dockerfile for OpenShift restricted security context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,17 +9,14 @@ ENV NPM_CONFIG_CACHE=/opt/app-root/src/app/.npm-cache
 # Set working directory
 WORKDIR /opt/app-root/src/app
 
+# Grant full permissions on working dir
+RUN chmod -R 777 /opt/app-root/src/app
+
 # Copy application source code
 COPY . /opt/app-root/src
 
-# Switch to root user to change ownership
-USER root
-
 # Create the npm cache directory and ensure the correct ownership
-RUN mkdir -p $NPM_CONFIG_CACHE && chown -R 1001:1001 /opt/app-root/src/app
-
-# Switch back to non-root user
-USER 1001:1001
+RUN mkdir -p $NPM_CONFIG_CACHE
 
 # Install dependencies and build the application
 RUN npm run all:ci \


### PR DESCRIPTION
# Description

When MALS 2 is deployed to OpenShift, the pod security context and container security context default to '**restricted**'. 

With Kubernetes restricted security context: 
- Pods cannot run as privileged
- Pods cannot mount host directory volumes
- Requires that a pod is run as a user in a pre-allocated range of UIDs
- Requires that a pod is run with a pre-allocated [Multi-Category Security (MCS)](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/using_selinux/assembly_using-multi-category-security-mcs-for-data-confidentiality_using-selinux#con_multi-category-security-mcs_assembly_using-multi-category-security-mcs-for-data-confidentiality) label

More info: [OpenShift Security Context Documentation](https://docs.openshift.com/container-platform/4.8/authentication/managing-security-context-constraints.html)

## Types of changes

Removes use of **root** user and **1001** user from Dockerfile, as it is suspected that this is causing issues when MALS 2 pods restart (e.g. during Platform upgrades). 
## Checklist

- [ x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate