### PR TITLE
fix: fixed branch name for merge and anlysis workflows

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -2,7 +2,7 @@ name: Analysis
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
   schedule:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -2,7 +2,7 @@ name: Merge
 
 on:
   push:
-    branches: [main]
+    branches: [master]
     paths-ignore:
       - '*.md'
       - '.github/**'

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -3,7 +3,6 @@ require("dotenv").config();
 const express = require("express");
 const Problem = require("api-problem");
 const httpContext = require("express-http-context");
-const path = require("path");
 const cookieParser = require("cookie-parser");
 const logger = require("morgan");
 const helmet = require("helmet");

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,7 +1,7 @@
 // Test scaffolding - to be implemented in future branches
 describe('App Component', () => {
   test.skip('should render main application', () => {
-    // TODO: Implement App component rendering test
+    // TODO: Implement App component rendering tests
   })
 
   test.skip('should handle authentication flow', () => {


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to trigger on pushes to the `master` branch instead of `main`. This ensures that both the analysis and merge workflows run on the correct branch for your repository.

**Workflow configuration updates:**

* [`.github/workflows/analysis.yml`](diffhunk://#diff-031cd11ded42e6a4bc0b585eb365588373263b8cc361cfb6e8685266d56621e4L5-R5): Changed the trigger branch for the analysis workflow from `main` to `master`.
* [`.github/workflows/merge.yml`](diffhunk://#diff-bdb37b2ad65e049a0fc043e88813fdcf7ca0118abc11d99bbda676adfcbbb5a1L5-R5): Changed the trigger branch for the merge workflow from `main` to `master`.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-mals-532-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-mals-532-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-mals/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-mals/actions/workflows/merge.yml)