### PR TITLE
Potential fix for code scanning alert no. 216: Type confusion through parameter tampering

### DIFF
--- a/backend/src/routes/v1/licences.js
+++ b/backend/src/routes/v1/licences.js
@@ -141,8 +141,16 @@ function getSearchFilter(params) {
     const regionalDistrictId = parseInt(params.regionalDistrict, 10);
 
     if (params.licenceTypeIdArray !== undefined) {
-      for (let i = 0; i < params.licenceTypeIdArray.length; ++i) {
-        orArray.push({ licence_type_id: params.licenceTypeIdArray[i] });
+      let arr;
+      if (Array.isArray(params.licenceTypeIdArray)) {
+        arr = params.licenceTypeIdArray;
+      } else if (typeof params.licenceTypeIdArray === 'string' && params.licenceTypeIdArray.length > 0) {
+        arr = [params.licenceTypeIdArray];
+      } else {
+        arr = [];
+      }
+      for (let i = 0; i < arr.length; ++i) {
+        orArray.push({ licence_type_id: arr[i] });
       }
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/nr-mals/security/code-scanning/216](https://github.com/bcgov/nr-mals/security/code-scanning/216)

The best way to fix this is to check the type of `params.licenceTypeIdArray` before iterating over it as an array. If it is not an array (and not undefined), handle it either as a single value or ignore it according to expected functionality. In this case, if the parameter is a string (single value), convert it to an array with one element, so subsequent code works uniformly. This ensures the loop on line 144 iterates only over integer IDs as intended and avoids silent type confusion if a string sneaks in. The fix should be implemented inside the `getSearchFilter` function, near lines 143–147, by normalizing the parameter to always be an array or skipping if it is not array-like.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
